### PR TITLE
New count command

### DIFF
--- a/app/App/Commands.hs
+++ b/app/App/Commands.hs
@@ -1,5 +1,6 @@
 module App.Commands where
 
+import App.Commands.Count
 import App.Commands.CreateIndex
 import App.Commands.Demo
 import Data.Semigroup           ((<>))
@@ -12,4 +13,5 @@ commandsGeneral :: Parser (IO ())
 commandsGeneral = subparser $ mempty
   <>  commandGroup "Commands:"
   <>  cmdCreateIndex
+  <>  cmdCount
   <>  cmdDemo

--- a/app/App/Commands/Count.hs
+++ b/app/App/Commands/Count.hs
@@ -1,0 +1,85 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+
+module App.Commands.Count
+  ( cmdCount
+  ) where
+
+import Control.Lens
+import Control.Monad
+import Data.Generics.Product.Any
+import Data.Semigroup                                         ((<>))
+import Data.Word
+import HaskellWorks.Data.FromForeignRegion
+import HaskellWorks.Data.Json.Backend.Standard.Cursor.Generic
+import HaskellWorks.Data.Json.LightJson
+import HaskellWorks.Data.Json.Query
+import HaskellWorks.Data.MQuery
+import HaskellWorks.Data.MQuery.Micro
+import HaskellWorks.Data.RankSelect.CsPoppy
+import HaskellWorks.Data.TreeCursor
+import Options.Applicative                                    hiding (columns)
+
+import qualified App.Commands.Types                        as Z
+import qualified Data.ByteString                           as BS
+import qualified Data.ByteString.Internal                  as BSI
+import qualified Data.DList                                as DL
+import qualified Data.Vector.Storable                      as DVS
+import qualified HaskellWorks.Data.BalancedParens.RangeMin as RM
+import qualified System.IO.MMap                            as IO
+
+siblings :: GenericCursor BSI.ByteString CsPoppy (RM.RangeMin CsPoppy) -> [GenericCursor BSI.ByteString CsPoppy (RM.RangeMin CsPoppy)]
+siblings c = c:cs
+  where cs = case nextSibling c of
+          Just d  -> siblings d
+          Nothing -> []
+
+runCount :: Z.CountOptions -> IO ()
+runCount opts = do
+  let inputFile   = opts ^. the @"inputFile"
+  let ibIndex     = opts ^. the @"ibIndex"
+  let bpIndex     = opts ^. the @"bpIndex"
+  let expression  = opts ^. the @"expression"
+  jsonFr    <- IO.mmapFileForeignPtr inputFile IO.ReadOnly Nothing
+  jsonIbFr  <- IO.mmapFileForeignPtr ibIndex   IO.ReadOnly Nothing
+  jsonBpFr  <- IO.mmapFileForeignPtr bpIndex   IO.ReadOnly Nothing
+  let jsonBs  = fromForeignRegion jsonFr    :: BS.ByteString
+  let jsonIb  = fromForeignRegion jsonIbFr  :: DVS.Vector Word64
+  let jsonBp  = fromForeignRegion jsonBpFr  :: DVS.Vector Word64
+
+  let cursor = GenericCursor jsonBs (makeCsPoppy jsonIb) (RM.mkRangeMin (makeCsPoppy jsonBp)) 1
+
+  let q = MQuery (DL.fromList $ fmap lightJsonAt (siblings cursor))
+
+  putPretty $ q >>= (entry >=> named expression) & count
+
+  return ()
+
+optsCount :: Parser Z.CountOptions
+optsCount = Z.CountOptions
+  <$> strOption
+        (   long "input"
+        <>  short 'i'
+        <>  help "Input JSON file"
+        <>  metavar "FILE"
+        )
+  <*> strOption
+        (   long "ib-index"
+        <>  help "IB index"
+        <>  metavar "FILE"
+        )
+  <*> strOption
+        (   long "bp-index"
+        <>  help "BP index"
+        <>  metavar "FILE"
+        )
+  <*> option auto
+        (   long "expression"
+        <>  help "JSON expression"
+        <>  metavar "EXPRESSION"
+        )
+
+cmdCount :: Mod CommandFields (IO ())
+cmdCount = command "count"  $ flip info idm $ runCount <$> optsCount

--- a/app/App/Commands/Types.hs
+++ b/app/App/Commands/Types.hs
@@ -2,10 +2,12 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 
 module App.Commands.Types
-  ( CreateIndexOptions(..)
+  ( CountOptions(..)
+  , CreateIndexOptions(..)
   , DemoOptions(..)
   ) where
 
+import Data.Text    (Text)
 import GHC.Generics
 
 data CreateIndexOptions = CreateIndexOptions
@@ -19,4 +21,11 @@ data CreateIndexOptions = CreateIndexOptions
 data DemoOptions = DemoOptions
   { filePath :: FilePath
   , method   :: FilePath
+  } deriving (Eq, Show, Generic)
+
+data CountOptions = CountOptions
+  { inputFile  :: FilePath
+  , ibIndex    :: FilePath
+  , bpIndex    :: FilePath
+  , expression :: Text
   } deriving (Eq, Show, Generic)

--- a/hw-json.cabal
+++ b/hw-json.cabal
@@ -166,6 +166,7 @@ executable hw-json
           , mmap
           , optparse-applicative
           , semigroups
+          , text
           , vector
   main-is:            Main.hs
   hs-source-dirs:     app
@@ -174,6 +175,7 @@ executable hw-json
   other-modules:
       App.Commands
       App.Commands.CreateIndex
+      App.Commands.Count
       App.Commands.Demo
       App.Commands.Types
 

--- a/src/HaskellWorks/Data/Json/Backend/Standard/Fast.hs
+++ b/src/HaskellWorks/Data/Json/Backend/Standard/Fast.hs
@@ -15,7 +15,6 @@ import HaskellWorks.Data.RankSelect.CsPoppy
 import qualified Data.ByteString                                       as BS
 import qualified Data.ByteString.Char8                                 as BSC
 import qualified Data.ByteString.Internal                              as BSI
-import qualified HaskellWorks.Data.BalancedParens                      as BP
 import qualified HaskellWorks.Data.BalancedParens.RangeMin             as RM
 import qualified HaskellWorks.Data.FromForeignRegion                   as F
 import qualified HaskellWorks.Data.Json.Internal.Backend.Standard.IbBp as J


### PR DESCRIPTION
```
$ ls -lh ~/zmap.json
-rw-r--r--  1 jky  staff    14G 14 Jun 14:53 /Users/jky/zmap.json
$ head ~/zmap.json
{"ip":"104.27.134.122","data":{"tls":{"status":"unknown-error","protocol":"tls","timestamp":"2019-06-12T00:13:38-04:00","error":"remote error: handshake failure"}}}
{"ip":"104.28.2.204","data":{"tls":{"status":"unknown-error","protocol":"tls","timestamp":"2019-06-12T00:13:38-04:00","error":"remote error: handshake failure"}}}
{"ip":"174.129.15.98","data":{"tls":{"status":"connection-timeout","protocol":"tls","timestamp":"2019-06-12T00:13:38-04:00","error":"dial tcp 146.88.240.2:0-\u003e174.129.15.98:443: connect: connection refused"}}}
{"ip":"130.193.118.227","data":{"tls":{"status":"connection-timeout","protocol":"tls","timestamp":"2019-06-12T00:13:38-04:00","error":"dial tcp 146.88.240.2:0-\u003e130.193.118.227:443: connect: no route to host"}}}
{"ip":"194.76.4.157","data":{"tls":{"status":"io-timeout","protocol":"tls","timestamp":"2019-06-12T00:13:38-04:00","error":"EOF"}}}
{"ip":"79.230.72.102","data":{"tls":{"status":"connection-timeout","protocol":"tls","timestamp":"2019-06-12T00:13:38-04:00","error":"dial tcp 146.88.240.2:0-\u003e79.230.72.102:443: connect: no route to host"}}}
{"ip":"35.244.130.221","data":{"tls":{"status":"io-timeout","protocol":"tls","timestamp":"2019-06-12T00:13:38-04:00","error":"EOF"}}}
{"ip":"188.209.52.7","data":{"tls":{"status":"connection-timeout","protocol":"tls","timestamp":"2019-06-12T00:13:39-04:00","error":"dial tcp 146.88.240.2:0-\u003e188.209.52.7:443: connect: connection refused"}}}
{"ip":"104.131.243.246","data":{"tls":{"status":"unknown-error","protocol":"tls","timestamp":"2019-06-12T00:13:38-04:00","error":"tls: oversized record received with length 20527"}}}
{"ip":"35.211.237.38","data":{"tls":{"status":"io-timeout","protocol":"tls","timestamp":"2019-06-12T00:13:39-04:00","error":"EOF"}}}
$ time wc -l ~/zmap.json
 3693582 /Users/jky/zmap.json
wc -l ~/zmap.json  9.11s user 11.21s system 94% cpu 21.399 total
$ time hw-json create-index -i ~/zmap.json -b standard -m simd --output-ib-file ~/zmap.json.ib --output-bp-file ~/zmap.json.bp
hw-json create-index -i ~/zmap.json -b standard -m simd --output-ib-file     23.20s user 9.90s system 122% cpu 26.979 total
$ time hw-json count --input ~/zmap.json --ib-index ~/zmap.json.ib --bp-index ~/zmap.json.bp --expression '"ip"'
==> 3693583
```