### PR TITLE
New count-aeson command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ cabal.sandbox.config
 /data
 /corpus
 /*.json
+/*.jsonl
 /*.json.ib
 /*.json.bp
 /snapshot.yaml

--- a/app/App/Commands.hs
+++ b/app/App/Commands.hs
@@ -1,6 +1,7 @@
 module App.Commands where
 
 import App.Commands.Count
+import App.Commands.CountAeson
 import App.Commands.CreateIndex
 import App.Commands.Demo
 import Data.Semigroup           ((<>))
@@ -14,4 +15,5 @@ commandsGeneral = subparser $ mempty
   <>  commandGroup "Commands:"
   <>  cmdCreateIndex
   <>  cmdCount
+  <>  cmdCountAeson
   <>  cmdDemo

--- a/app/App/Commands/Count.hs
+++ b/app/App/Commands/Count.hs
@@ -88,7 +88,7 @@ optsCount = Z.CountOptions
         <>  metavar "FILE"
         )
   <*> optional optsFileIndex
-  <*> option auto
+  <*> strOption
         (   long "expression"
         <>  help "JSON expression"
         <>  metavar "EXPRESSION"

--- a/app/App/Commands/CountAeson.hs
+++ b/app/App/Commands/CountAeson.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+
+module App.Commands.CountAeson
+  ( cmdCountAeson
+  ) where
+
+import Control.Lens
+import Data.Generics.Product.Any
+import Data.Semigroup            ((<>))
+import Options.Applicative       hiding (columns)
+
+import qualified App.Commands.Types   as Z
+import qualified Data.Aeson           as J
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.HashMap.Strict  as SHM
+import qualified System.IO            as IO
+
+runCountAeson :: Z.CountAesonOptions -> IO ()
+runCountAeson opts = do
+  let inputFile   = opts ^. the @"inputFile"
+  let expression  = opts ^. the @"expression"
+
+  lbs <- LBS.readFile inputFile
+
+  let lbsLines = LBS.split 10 lbs
+
+  let count :: Int = sum $ flip fmap lbsLines $ \lbsLine -> case J.decode lbsLine of
+        Just (J.Object v) -> if SHM.member expression v then 1 else 0
+        _                 -> 0
+
+  IO.putStrLn $ "Count: " <> show count
+
+  return ()
+
+optsCountAeson :: Parser Z.CountAesonOptions
+optsCountAeson = Z.CountAesonOptions
+  <$> strOption
+        (   long "input"
+        <>  short 'i'
+        <>  help "Input JSON file"
+        <>  metavar "FILE"
+        )
+  <*> strOption
+        (   long "expression"
+        <>  help "JSON expression"
+        <>  metavar "EXPRESSION"
+        )
+
+cmdCountAeson :: Mod CommandFields (IO ())
+cmdCountAeson = command "count-aeson"  $ flip info idm $ runCountAeson <$> optsCountAeson

--- a/app/App/Commands/Types.hs
+++ b/app/App/Commands/Types.hs
@@ -2,7 +2,8 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 
 module App.Commands.Types
-  ( CountOptions(..)
+  ( CountAesonOptions(..)
+  , CountOptions(..)
   , CreateIndexOptions(..)
   , DemoOptions(..)
   , FileIndexes(..)
@@ -27,6 +28,11 @@ data DemoOptions = DemoOptions
 data CountOptions = CountOptions
   { inputFile  :: FilePath
   , indexes    :: Maybe FileIndexes
+  , expression :: Text
+  } deriving (Eq, Show, Generic)
+
+data CountAesonOptions = CountAesonOptions
+  { inputFile  :: FilePath
   , expression :: Text
   } deriving (Eq, Show, Generic)
 

--- a/hw-json.cabal
+++ b/hw-json.cabal
@@ -69,6 +69,7 @@ common optparse-applicative     { build-depends: optparse-applicative     >= 0.1
 common scientific               { build-depends: scientific               >= 0.3.6.2    && < 0.4    }
 common text                     { build-depends: text                     >= 1.2        && < 1.3    }
 common transformers             { build-depends: transformers             >= 0.4        && < 0.6    }
+common unordered-containers     { build-depends: unordered-containers     >= 0.2        && < 0.3    }
 common vector                   { build-depends: vector                   >= 0.12       && < 0.13   }
 common word8                    { build-depends: word8                    >= 0.1        && < 0.2    }
 
@@ -132,6 +133,7 @@ library
 
 executable hw-json
   import:               base, config
+                      , aeson
                       , bytestring
                       , dlist
                       , generic-lens
@@ -148,6 +150,7 @@ executable hw-json
                       , optparse-applicative
                       , semigroups
                       , text
+                      , unordered-containers
                       , vector
   main-is:              Main.hs
   hs-source-dirs:       app
@@ -156,6 +159,7 @@ executable hw-json
   other-modules:        App.Commands
                         App.Commands.CreateIndex
                         App.Commands.Count
+                        App.Commands.CountAeson
                         App.Commands.Demo
                         App.Commands.Types
 


### PR DESCRIPTION
New `count-aeson` command as a baseline to evaluate the performance of the SIMD enabled succinct data structure based `count` command:

```
$ time hw-json count-aeson -i 78mb.jsonl --expression _id
Count: 18801
hw-json count-aeson -i 78mb.jsonl --expression _id  3.75s user 0.61s system 279% cpu 1.559 total
$ time hw-json count -i 78mb.jsonl --expression _id
==> 18801
hw-json count -i 78mb.jsonl --expression _id  1.15s user 0.14s system 172% cpu 0.746 total
```