### PR TITLE
Remove simd on aarch64, but compile.

### DIFF
--- a/app/App/Commands/Count.hs
+++ b/app/App/Commands/Count.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -35,6 +36,9 @@ siblings :: GenericCursor BSI.ByteString CsPoppy1 (RM.RangeMin CsPoppy1) -> [Gen
 siblings c = c:maybe [] siblings (nextSibling c)
 
 runCount :: Z.CountOptions -> IO ()
+#if aarch64_HOST_ARCH
+runCount = undefined
+#else
 runCount opts = do
   let inputFile   = opts ^. the @"inputFile"
   let expression  = opts ^. the @"expression"
@@ -61,6 +65,7 @@ runCount opts = do
   putPretty $ q >>= (entry >=> named expression) & count
 
   return ()
+#endif
 
 optsFileIndex :: Parser Z.FileIndexes
 optsFileIndex = Z.FileIndexes

--- a/app/App/Commands/CreateIndex.hs
+++ b/app/App/Commands/CreateIndex.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
@@ -21,7 +22,9 @@ import qualified Data.ByteString.Internal                                       
 import qualified Data.ByteString.Lazy                                               as LBS
 import qualified HaskellWorks.Data.ByteString                                       as BS
 import qualified HaskellWorks.Data.ByteString.Lazy                                  as LBS
+#if x86_64_HOST_ARCH
 import qualified HaskellWorks.Data.Json.Simd.Index.Standard                         as STSI
+#endif
 import qualified HaskellWorks.Data.Json.Simple.Cursor.SemiIndex                     as SISI
 import qualified HaskellWorks.Data.Json.Standard.Cursor.Internal.Blank              as J
 import qualified HaskellWorks.Data.Json.Standard.Cursor.Internal.BlankedJson        as J
@@ -36,6 +39,7 @@ import qualified System.IO.MMap                                                 
 {- HLINT ignore "Redundant do"       -}
 
 runCreateIndexStandard :: Z.CreateIndexOptions -> IO ()
+#if x86_64_HOST_ARCH
 runCreateIndexStandard opts = do
   let filePath = opts ^. the @"filePath"
   let outputIbFile = opts ^. the @"outputIbFile" & fromMaybe (filePath <> ".ib.idx")
@@ -80,8 +84,12 @@ runCreateIndexStandard opts = do
     unknown -> do
       IO.hPutStrLn IO.stderr $ "Unknown method " <> show unknown
       IO.exitFailure
+#else
+runCreateIndexStandard opts = undefined
+#endif
 
 runCreateIndexSimple :: Z.CreateIndexOptions -> IO ()
+#if x86_64_HOST_ARCH
 runCreateIndexSimple opts = do
   let filePath = opts ^. the @"filePath"
   let outputIbFile = opts ^. the @"outputIbFile" & fromMaybe (filePath <> ".ib.idx")
@@ -91,6 +99,9 @@ runCreateIndexSimple opts = do
   let SISI.SemiIndex _ ibs bps = SISI.buildSemiIndex bs
   LBS.writeFile outputIbFile (LBS.toLazyByteString ibs)
   LBS.writeFile outputBpFile (LBS.toLazyByteString bps)
+#else
+runCreateIndexSimple opts = undefined
+#endif
 
 runCreateIndex :: Z.CreateIndexOptions -> IO ()
 runCreateIndex opts = case opts ^. the @"backend" of

--- a/app/App/Commands/Demo.hs
+++ b/app/App/Commands/Demo.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -29,7 +30,9 @@ import qualified Data.ByteString.Lazy                       as LBS
 import qualified Data.DList                                 as DL
 import qualified HaskellWorks.Data.BalancedParens.RangeMin  as RM
 import qualified HaskellWorks.Data.ByteString.Lazy          as LBS
+#if x86_64_HOST_ARCH
 import qualified HaskellWorks.Data.Json.Simd.Index.Standard as S
+#endif
 import qualified Options.Applicative                        as OA
 import qualified System.IO                                  as IO
 import qualified System.IO.MMap                             as IO
@@ -37,6 +40,7 @@ import qualified System.IO.MMap                             as IO
 {- HLINT ignore "Reduce duplication" -}
 
 runDemo :: Z.DemoOptions -> IO ()
+#if x86_64_HOST_ARCH
 runDemo opts = do
   let filePath = opts ^. the @"filePath"
   case opts ^. the @"method" of
@@ -59,6 +63,9 @@ runDemo opts = do
           putPretty $ q >>= (entry >=> named "meta" >=> entry >=> named "view" >=> entry >=> named "columns" >=> item >=> entry >=> named "id") & count
         Left msg -> IO.hPutStrLn IO.stderr $ "Unable to create semi-index: " <> show msg
     m -> IO.hPutStrLn IO.stderr $ "Unrecognised method: " <> show m
+#else
+runDemo opts = undefined
+#endif
 
 optsDemo :: Parser Z.DemoOptions
 optsDemo = Z.DemoOptions

--- a/hw-json.cabal
+++ b/hw-json.cabal
@@ -56,7 +56,10 @@ common hspec                      { build-depends: hspec                      >=
 common hw-balancedparens          { build-depends: hw-balancedparens          >= 0.3.0.0    && < 0.5    }
 common hw-bits                    { build-depends: hw-bits                    >= 0.7.0.5    && < 0.8    }
 common hw-hspec-hedgehog          { build-depends: hw-hspec-hedgehog          >= 0.1.0.4    && < 0.2    }
-common hw-json-simd               { build-depends: hw-json-simd               >= 0.1.0.2    && < 0.2    }
+common hw-json-simd {
+  if arch(x86_64)
+    build-depends: hw-json-simd               >= 0.1.0.2    && < 0.2
+}
 common hw-json-simple-cursor      { build-depends: hw-json-simple-cursor      >= 0.1.0.1    && < 0.2    }
 common hw-json-standard-cursor    { build-depends: hw-json-standard-cursor    >= 0.2.0.1    && < 0.3    }
 common hw-mquery                  { build-depends: hw-mquery                  >= 0.2.0.0    && < 0.3    }
@@ -64,7 +67,10 @@ common hw-parser                  { build-depends: hw-parser                  >=
 common hw-prim                    { build-depends: hw-prim                    >= 0.6.2.32   && < 0.7    }
 common hw-rankselect              { build-depends: hw-rankselect              >= 0.13       && < 0.14   }
 common hw-rankselect-base         { build-depends: hw-rankselect-base         >= 0.3.2.1    && < 0.4    }
-common hw-simd                    { build-depends: hw-simd                    >= 0.1.1.2    && < 0.2    }
+common hw-simd {
+  if arch(x86_64)
+    build-depends: hw-simd                    >= 0.1.1.2    && < 0.2
+}
 common lens                       { build-depends: lens                       >= 4          && < 6      }
 common mmap                       { build-depends: mmap                       >= 0.5        && < 0.6    }
 common optparse-applicative       { build-depends: optparse-applicative       >= 0.14       && < 0.18   }


### PR DESCRIPTION
We compile programs that depend on hw-json for both x86_64 and aarch64. Of course the simd extensions won't be available on aarch64 but it would be nice if hw-json could compile for the platform, anyways.

I think this would also need to be done in the cursor libraries, too. Or maybe this should instead be done in hw-simd or hw-json-simd instead? What do you think?