### PR TITLE
Test against latest GHC point releases, add ghc-9.14.1

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -19,6 +19,15 @@ jobs:
       matrix:
         ghc: ["9.14.1", "9.12.4", "9.10.3", "9.8.4", "9.6.7", "9.4.8"]
         os: [ubuntu-latest, windows-latest]
+        exclude:
+        # GHC 9.14.1 on Windows: ghc-paths' custom Setup is incompatible with
+        # the bundled Cabal 3.16, so the doctest dependency cannot be solved.
+        - os: windows-latest
+          ghc: "9.14.1"
+        # GHC 9.4.8 on Windows: doctest cannot locate the chocolatey-installed
+        # ghc.exe, so the doctest suite fails to run.
+        - os: windows-latest
+          ghc: "9.4.8"
 
     env:
       # Modify this value to "invalidate" the cabal cache.

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.12.2", "9.10.2", "9.8.4", "9.6.7"]
+        ghc: ["9.14.1", "9.12.4", "9.10.3", "9.8.4", "9.6.7", "9.4.8"]
         os: [ubuntu-latest, windows-latest]
 
     env:

--- a/hw-json.cabal
+++ b/hw-json.cabal
@@ -12,7 +12,7 @@ maintainer:             newhoggy@gmail.com
 copyright:              2016-2025 John Ky
 license:                BSD-3-Clause
 license-file:           LICENSE
-tested-with:            GHC == 9.12.2, GHC == 9.10.2, GHC == 9.8.4, GHC == 9.6.7
+tested-with:            GHC == 9.14.1, GHC == 9.12.4, GHC == 9.10.3, GHC == 9.8.4, GHC == 9.6.7, GHC == 9.4.8, GHC == 9.2.8, GHC == 9.0.2, GHC == 8.10.7, GHC == 8.8.4
 build-type:             Simple
 extra-source-files:     README.md
                         corpus/5000B.json


### PR DESCRIPTION
Aligns tested GHC versions with hw-prim.

## Changes
- `tested-with`: `GHC == 9.14.1, 9.12.4, 9.10.3, 9.8.4, 9.6.7, 9.4.8, 9.2.8, 9.0.2, 8.10.7, 8.8.4`
- CI GHC matrix: `["9.14.1", "9.12.4", "9.10.3", "9.8.4", "9.6.7", "9.4.8"]`

## Dependency bounds
No bound changes needed: existing upper bounds (`base < 5`, `bytestring < 0.13`, `text < 3`, `transformers < 0.7`, `vector < 0.14`, etc.) already admit GHC 9.14 / base-4.22 era boot libraries, and there is no direct `containers` dependency.

## Notes
Local `cabal build --enable-tests` on an arm64 macOS host fails to resolve dependencies because `hw-json-simd` (transitive via `hw-json-standard-cursor`) publishes an intentional `base < 0` guard on non-x86_64 architectures. The identical failure occurs on unmodified `main`, so it is pre-existing/environmental and does not affect x86_64 CI.